### PR TITLE
fix: removed unused method, changed to return correct value

### DIFF
--- a/common/src/main/java/net/satisfy/bakery/core/recipe/BakingStationRecipe.java
+++ b/common/src/main/java/net/satisfy/bakery/core/recipe/BakingStationRecipe.java
@@ -5,7 +5,6 @@ import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.resources.ResourceLocation;
@@ -33,7 +32,7 @@ public class BakingStationRecipe implements Recipe<RecipeInput> {
 
     @Override
     public ItemStack assemble(RecipeInput recipeInput, HolderLookup.Provider provider) {
-        return ItemStack.EMPTY;
+        return this.getResultItem(provider);
     }
 
     @Override
@@ -43,10 +42,6 @@ public class BakingStationRecipe implements Recipe<RecipeInput> {
 
     @Override
     public ItemStack getResultItem(HolderLookup.Provider provider) {
-        return null;
-    }
-
-    public @NotNull ItemStack getResultItem(RegistryAccess registryAccess) {
         return this.output.copy();
     }
 


### PR DESCRIPTION
1. `ItemStack getResultItem(RegistryAccess)` is This is the convention used in 1.20.1.
2. Fixed to `ItemStack assemble(RecipeInput, HolderLookup.Provider)` will return `output`.

```java
public @NotNull ItemStack getResultItem(RegistryAccess registryAccess) {
	return this.output.copy();
}
```